### PR TITLE
audiopolicy: squashed support for pre-kitkat audio blobs

### DIFF
--- a/services/audiopolicy/Android.mk
+++ b/services/audiopolicy/Android.mk
@@ -40,6 +40,10 @@ LOCAL_SHARED_LIBRARIES += \
     libaudiopolicymanager
 endif
 
+ifeq ($(BOARD_HAVE_PRE_KITKAT_AUDIO_POLICY_BLOB),true)
+    LOCAL_CFLAGS += -DHAVE_PRE_KITKAT_AUDIO_POLICY_BLOB
+endif
+
 LOCAL_STATIC_LIBRARIES := \
     libmedia_helper \
     libaudiopolicycomponents

--- a/services/audiopolicy/service/AudioPolicyClientImplLegacy.cpp
+++ b/services/audiopolicy/service/AudioPolicyClientImplLegacy.cpp
@@ -125,8 +125,13 @@ audio_io_handle_t aps_open_output_on_module(void *service __unused,
                                                    audio_output_flags_t flags,
                                                    const audio_offload_info_t *offloadInfo)
 {
+#ifdef HAVE_PRE_KITKAT_AUDIO_POLICY_BLOB
+    return open_output(module, pDevices, pSamplingRate, pFormat, pChannelMask,
+                          pLatencyMs, flags, NULL);
+#else
     return open_output(module, pDevices, pSamplingRate, pFormat, pChannelMask,
                           pLatencyMs, flags, offloadInfo);
+#endif
 }
 
 audio_io_handle_t aps_open_dup_output(void *service __unused,

--- a/services/audiopolicy/service/AudioPolicyInterfaceImplLegacy.cpp
+++ b/services/audiopolicy/service/AudioPolicyInterfaceImplLegacy.cpp
@@ -275,6 +275,11 @@ status_t AudioPolicyService::getInputForAttr(const audio_attributes_t *attr,
         return BAD_VALUE;
     }
 
+#ifdef HAVE_PRE_KITKAT_AUDIO_POLICY_BLOB
+    if (inputSource == AUDIO_SOURCE_HOTWORD)
+        inputSource = AUDIO_SOURCE_VOICE_RECOGNITION;
+#endif
+
     sp<AudioPolicyEffects>audioPolicyEffects;
     {
         Mutex::Autolock _l(mLock);
@@ -524,6 +529,9 @@ status_t AudioPolicyService::queryDefaultPreProcessing(int audioSession,
 
 bool AudioPolicyService::isOffloadSupported(const audio_offload_info_t& info)
 {
+#ifdef HAVE_PRE_KITKAT_AUDIO_POLICY_BLOB
+    return false;
+#else
     if (mpAudioPolicy == NULL) {
         ALOGV("mpAudioPolicy == NULL");
         return false;
@@ -535,6 +543,7 @@ bool AudioPolicyService::isOffloadSupported(const audio_offload_info_t& info)
     }
 
     return mpAudioPolicy->is_offload_supported(mpAudioPolicy, &info);
+#endif
 }
 
 status_t AudioPolicyService::listAudioPorts(audio_port_role_t role __unused,


### PR DESCRIPTION
Squash of the following:

commit 40c41a743a4345ad26b6eab41755c5b474f75853
Author: chrmhoffmann chrmhoffmann@gmail.com
Date:   Sat Nov 29 19:32:27 2014 +0100

```
pre kitkat audio legacy policy fix for hotword (ok google)

Change-Id: I5bb90fb90f373461a98609226a5cea50ac5266e9
```

commit d47b306954b96142323c79b976edeb3eaa3b46dd
Author: chrmhoffmann chrmhoffmann@gmail.com
Date:   Sun Nov 23 18:22:35 2014 +0100
commit d47b306954b96142323c79b976edeb3eaa3b46dd
Author: chrmhoffmann chrmhoffmann@gmail.com
Date:   Sun Nov 23 18:22:35 2014 +0100

```
pre-kitkat audio policy blobs re-activated.

Change-Id: Idfcb03d0a4aa0a099bf5a17b7bf592ab402e3255
```

Change-Id: Iae65c6ccb6dcb120a6fc20978b8a69e6af39a51a
